### PR TITLE
Add a " const " before "alg" and "typ" variable

### DIFF
--- a/src/CustomJWT.h
+++ b/src/CustomJWT.h
@@ -33,7 +33,7 @@ public:
 
     /**
      * @brief Construct a new CustomJWT object
-     * 
+     *
      * @param secret The Hashing key
      * @param maxPayloadLen Maximum expected length of payload
      * @param maxHeadLen Maximum expected length of header. Defaults to 40.
@@ -41,11 +41,11 @@ public:
      * @param alg Encryption algorithm used. Defaults to HS256.
      * @param typ Header type. Defaults to JWT.
      */
-    CustomJWT(char *secret, 
-              size_t maxPayloadLen, 
-              size_t maxHeadLen = 40, 
-              size_t maxSigLen = 32, 
-              const char *alg = "HS256", 
+    CustomJWT(char *secret,
+              size_t maxPayloadLen,
+              size_t maxHeadLen = 40,
+              size_t maxSigLen = 32,
+              const char *alg = "HS256",
               const char *typ = "JWT")
     {
         this->secret = (uint8_t *)secret;
@@ -60,7 +60,7 @@ public:
 
     /**
      * @brief Construct a new CustomJWT object providing own char arrays to store JWT output
-     * 
+     *
      * @param secret The Hashing key
      * @param header Pointer to where the JWT header will be stored
      * @param headLen Size of header array
@@ -73,16 +73,16 @@ public:
      * @param alg Encryption algorithm used. Defaults to HS256.
      * @param typ Header type. Defaults to JWT.
      */
-    CustomJWT(char *secret, 
+    CustomJWT(char *secret,
               char *header,
               size_t headLen,
               char *payload,
               size_t payloadLen,
-              char *signature, 
+              char *signature,
               size_t signatureLen,
               char *out,
               size_t outLen,
-              const char *alg = "HS256", 
+              const char *alg = "HS256",
               const char *typ = "JWT")
     {
         this->secret = (uint8_t *)secret;
@@ -103,7 +103,7 @@ public:
 
     /**
      * @brief Construct a new CustomJWT object with a custom signature generation function
-     * 
+     *
      * @param secret The Hashing key
      * @param maxPayloadLen Maximum expected length of payload
      * @param maxHeadLen Maximum expected length of header. Defaults to 40.
@@ -112,11 +112,11 @@ public:
      * @param alg Encryption algorithm used
      * @param typ Header type. Defaults to JWT.
      */
-    CustomJWT(char *secret, 
-              size_t maxPayloadLen, 
-              size_t maxHeadLen, 
-              size_t maxSigLen, 
-              char *alg,
+    CustomJWT(char *secret,
+              size_t maxPayloadLen,
+              size_t maxHeadLen,
+              size_t maxSigLen,
+              const char *alg,
               void (*generateSignaturePointer)(char *output, size_t *outputLen, void *secret, size_t secretLen, void *data, size_t dataLen),
               const char *typ = "JWT")
     {
@@ -132,7 +132,7 @@ public:
 
     /**
      * @brief Construct a new CustomJWT object with a custom signature generation function
-     * 
+     *
      * @param secret The Hashing key
      * @param header Pointer to where the JWT header will be stored
      * @param headLen Size of header array
@@ -146,16 +146,16 @@ public:
      * @param generateSignaturePointer Pointer to hashing function for signature
      * @param typ Header type. Defaults to JWT.
      */
-    CustomJWT(char *secret, 
+    CustomJWT(char *secret,
               char *header,
               size_t headLen,
               char *payload,
               size_t payloadLen,
-              char *signature, 
+              char *signature,
               size_t signatureLen,
               char *out,
               size_t outLen,
-              char *alg,
+              const char *alg,
               void (*generateSignaturePointer)(char *output, size_t *outputLen, void *secret, size_t secretLen, void *data, size_t dataLen),
               const char *typ = "JWT")
     {
@@ -181,7 +181,7 @@ public:
      */
     bool allocateJWTMemory()
     {
-        if(staticAllocation)
+        if (staticAllocation)
             return false;
         b64HeaderLen = (size_t)(4.0 * (maxHeadLen / 3.0)) + 5;
         b64PayloadLen = (size_t)(4.0 * (maxPayloadLen / 3.0)) + 5;
@@ -205,8 +205,9 @@ public:
      * @param secretLen Length of secret
      * @param data Pointer to the data from which signature is to be generated
      * @param dataLen Size of data from which signature is to be generated
-    */
-    void generateSignature(char *output, size_t *outputLen, void *secret, size_t secretLen, void *data, size_t dataLen) {
+     */
+    void generateSignature(char *output, size_t *outputLen, void *secret, size_t secretLen, void *data, size_t dataLen)
+    {
         uint8_t hashed[SHA256_HASH];
         memset(hashed, 0, SHA256_HASH);
         hmac<SHA256>(hashed, SHA256_HASH, secret, secretLen, data, dataLen);
@@ -214,18 +215,18 @@ public:
     }
 
     /**
-     * @brief Encode given string into JWT. Final output stored in out. 
-     * 
+     * @brief Encode given string into JWT. Final output stored in out.
+     *
      * @param string Data to be encoded
      * @return true: Encoding success
      * @return false: Memory not allocated
      */
     bool encodeJWT(char *string)
     {
-        if(!memoryAllocationDone && !staticAllocation)
+        if (!memoryAllocationDone && !staticAllocation)
             return false;
 
-        if(!staticAllocation)
+        if (!staticAllocation)
         {
             memset(header, 0, sizeof(char) * b64HeaderLen);
             memset(payload, 0, sizeof(char) * b64PayloadLen);
@@ -245,16 +246,16 @@ public:
         Base64URL::base64urlEncode(headerJSON, strlen(headerJSON), header, &headerLength);
 
         Base64URL::base64urlEncode(string, strlen(string), payload, &payloadLength);
-        
+
         char toHash[payloadLength + headerLength + 3];
         memset(toHash, 0, payloadLength + headerLength + 3);
         sprintf(toHash, "%s.%s", header, payload);
-        
-        if(this->generateSignaturePointer == nullptr)
+
+        if (this->generateSignaturePointer == nullptr)
             generateSignature(signature, &signatureLength, secret, strlen((char *)secret), toHash, strlen(toHash));
         else
             generateSignaturePointer(signature, &signatureLength, secret, strlen((char *)secret), toHash, strlen(toHash));
-        
+
         sprintf(out, "%s.%s", toHash, signature);
         outputLength = strlen(out);
         return true;
@@ -262,33 +263,32 @@ public:
 
     /**
      * @brief Validate and decode JWT. Result stored int header, payload and signature.
-     * 
+     *
      * @param string JWT to be decoded
      * @returns Code 0: Decode success \n Code 1: Memory not allocated \n Code 2: Invalid JWT \n Code 3: Signature Mismatch
      */
     int decodeJWT(char *string)
     {
-        if(!memoryAllocationDone && !staticAllocation)
+        if (!memoryAllocationDone && !staticAllocation)
             return 1;
-        
-        const char* delimiter = ".";
-        char* b64Head;
-        char* b64Payload;
-        char* b64Signature;
 
-        
+        const char *delimiter = ".";
+        char *b64Head;
+        char *b64Payload;
+        char *b64Signature;
+
         b64Head = strtok(string, delimiter);
-        if(b64Head == 0)
+        if (b64Head == 0)
             return 2;
         b64Payload = strtok(0, delimiter);
-        if(b64Payload == 0)
+        if (b64Payload == 0)
             return 2;
         b64Signature = strtok(0, delimiter);
-        if(b64Signature == 0)
+        if (b64Signature == 0)
             return 2;
-        if(strtok(0, delimiter) != 0)
+        if (strtok(0, delimiter) != 0)
             return 2;
-        
+
         char toCheckHash[strlen(b64Head) + strlen(b64Payload) + 3];
         memset(toCheckHash, 0, sizeof(toCheckHash));
 
@@ -298,20 +298,22 @@ public:
 
         sprintf(toCheckHash, "%s.%s", b64Head, b64Payload);
 
-        if(generateSignaturePointer == nullptr)
-            generateSignature(testSignature, &testSignatureLength, secret, strlen((char*)secret), toCheckHash, strlen(toCheckHash));
+        if (generateSignaturePointer == nullptr)
+            generateSignature(testSignature, &testSignatureLength, secret, strlen((char *)secret), toCheckHash, strlen(toCheckHash));
         else
-            generateSignaturePointer(testSignature, &testSignatureLength, secret, strlen((char*)secret), toCheckHash, strlen(toCheckHash));
+            generateSignaturePointer(testSignature, &testSignatureLength, secret, strlen((char *)secret), toCheckHash, strlen(toCheckHash));
 
-        if(testSignatureLength != strlen(b64Signature)){
+        if (testSignatureLength != strlen(b64Signature))
+        {
             return 3;
         }
 
-        if(strncmp(b64Signature, testSignature, testSignatureLength) != 0) {
+        if (strncmp(b64Signature, testSignature, testSignatureLength) != 0)
+        {
             return 3;
         }
-        
-        if(!staticAllocation)
+
+        if (!staticAllocation)
         {
             memset(header, 0, sizeof(char) * b64HeaderLen);
             memset(payload, 0, sizeof(char) * b64PayloadLen);
@@ -323,12 +325,12 @@ public:
             memset(payload, 0, sizeof(char) * maxPayloadLen);
             memset(signature, 0, sizeof(char) * maxSigLen);
         }
-        
+
         Base64URL::base64urlDecode(b64Head, strlen(b64Head), header, &headerLength);
         Base64URL::base64urlDecode(b64Payload, strlen(b64Payload), payload, &payloadLength);
         sprintf(signature, "%s", b64Signature);
         signatureLength = strlen(signature);
-        
+
         return 0;
     }
 
@@ -338,24 +340,24 @@ public:
      */
     bool clear()
     {
-        if(staticAllocation)
+        if (staticAllocation)
             return false;
-        if(header != nullptr)
+        if (header != nullptr)
         {
             free(header);
             header = nullptr;
         }
-        if(payload != nullptr)
+        if (payload != nullptr)
         {
             free(payload);
             payload = nullptr;
         }
-        if(signature != nullptr)
+        if (signature != nullptr)
         {
             free(signature);
             signature = nullptr;
         }
-        if(out != nullptr)
+        if (out != nullptr)
         {
             free(out);
             out = nullptr;

--- a/src/CustomJWT.h
+++ b/src/CustomJWT.h
@@ -11,8 +11,8 @@ class CustomJWT
 {
 public:
     uint8_t *secret;
-    char *alg;
-    char *typ;
+    const char *alg;
+    const char *typ;
     size_t maxHeadLen;
     size_t maxPayloadLen;
     size_t maxSigLen;
@@ -45,8 +45,8 @@ public:
               size_t maxPayloadLen, 
               size_t maxHeadLen = 40, 
               size_t maxSigLen = 32, 
-              char *alg = "HS256", 
-              char *typ = "JWT")
+              const char *alg = "HS256", 
+              const char *typ = "JWT")
     {
         this->secret = (uint8_t *)secret;
         this->alg = alg;
@@ -82,8 +82,8 @@ public:
               size_t signatureLen,
               char *out,
               size_t outLen,
-              char *alg = "HS256", 
-              char *typ = "JWT")
+              const char *alg = "HS256", 
+              const char *typ = "JWT")
     {
         this->secret = (uint8_t *)secret;
         this->alg = alg;
@@ -118,7 +118,7 @@ public:
               size_t maxSigLen, 
               char *alg,
               void (*generateSignaturePointer)(char *output, size_t *outputLen, void *secret, size_t secretLen, void *data, size_t dataLen),
-              char *typ = "JWT")
+              const char *typ = "JWT")
     {
         this->secret = (uint8_t *)secret;
         this->alg = alg;
@@ -157,7 +157,7 @@ public:
               size_t outLen,
               char *alg,
               void (*generateSignaturePointer)(char *output, size_t *outputLen, void *secret, size_t secretLen, void *data, size_t dataLen),
-              char *typ = "JWT")
+              const char *typ = "JWT")
     {
         this->secret = (uint8_t *)secret;
         this->alg = alg;


### PR DESCRIPTION
Hi and Thank you for your wonderful application

To not display the warning : 
" ISO C++ forbids converting a string constant to 'char*' " Add a "const" before "alg" and "typ" variable

Please apply my changes if approved.